### PR TITLE
Use ocean-sound-theme module from runtime

### DIFF
--- a/org.kde.kteatime.json
+++ b/org.kde.kteatime.json
@@ -18,17 +18,6 @@
     ],
     "modules": [
         {
-            "name": "ocean-sound-theme",
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.kde.org/stable/plasma/6.3.5/ocean-sound-theme-6.3.5.tar.xz",
-                    "sha256": "e6ab2ef12ba392cdadbc4fa1043a4a1d5419b6177a086822f68c7a5b521798c3"
-                }
-            ]
-        },
-        {
             "name": "kteatime",
             "buildsystem": "cmake-ninja",
             "post-install": [


### PR DESCRIPTION
KDE runtime version 6.10 appears to provide the **ocean-sound-theme** module.

In most cases, you don't need to build these modules separately, unless your project requires a specific version or a custom configuration.

Fixes: https://github.com/flathub/org.kde.kteatime/issues/58